### PR TITLE
FastCGI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ BUILD ?= debug
 # if it doesn't compile with readline enabled, then try turning it off.
 READLINE ?= 1
 
+# this should reflect if FastCGI should be supported. Defaulting to no
+# Please note that this makes the resulting spn binary completly unusable for non-FastCGI uses
+FASTCGI ?= 0
+
 OPSYS = $(shell uname | tr '[[:upper:]]' '[[:lower:]]')
 ARCH = $(shell uname -p | tr '[[:upper:]]' '[[:lower:]]')
 
@@ -44,6 +48,13 @@ ifneq ($(READLINE), 0)
 	LIBS += -lreadline
 else
 	DEFINES += -DUSE_READLINE=0
+endif
+
+ifneq ($(FASTCGI), 0)
+	DEFINES += -DUSE_FASTCGI=1
+	LIBS += -lfcgi
+else
+	DEFINES += -DUSE_FASTCGI=0
 endif
 
 ifeq ($(BUILD), debug)

--- a/src/api.c
+++ b/src/api.c
@@ -8,7 +8,11 @@
  * Public parts of the Sparkling API
  */
 
+#if USE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <limits.h>
 #include <float.h>

--- a/src/rtlb.c
+++ b/src/rtlb.c
@@ -8,7 +8,11 @@
  * Run-time support library
  */
 
+#if USE_FASTCGI
+#include "fcgi_stdio.h"
+#else
 #include <stdio.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>


### PR DESCRIPTION
Adds FastCGI support, below is my example configuration.

test.spn:
```c
// example CGI script
print("Content-Type: text/html\r\n\r\n");
print("<html><head><title>Hello World!</title></head><body>");
print("<h1>Hello World from Sparkling!</h1>");
print("<a href=\"https://github.com/H2CO3/Sparkling\">Sparkling on github</a><br />");
print("Some environment variables follow:<br />");
print("<pre style=\"background-color: #EEEEEE;\">");
var vars = {
	"GATEWAY_INTERFACE": 1,
	"DOCUMENT_URI": 1,
	"REMOTE_ADDR": 1,
	"QUERY_STRING": 1,
	"FCGI_ROLE": 1,
	"DOCUMENT_ROOT": 1,
	"REMOTE_PORT": 1,
	"HTTP_USER_AGENT": 1,
	"HTTP_ACCEPT": 1,
	"SCRIPT_FILENAME": 1,
	"HTTP_HOST": 1,
	"REQUEST_URI": 1,
	"SERVER_SOFTWARE": 1,
	"HTTP_CONNECTION": 1,
	"HTTP_ACCEPT_LANGUAGE": 1,
	"SERVER_PROTOCOL": 1,
	"HTTP_ACCEPT_ENCODING": 1,
	"REDIRECT_STATUS": 1,
	"REQUEST_METHOD": 1,
	"SERVER_ADDR": 1,
	"SERVER_PORT": 1,
	"SCRIPT_NAME": 1,
	"SERVER_NAME": 1,
	"REMOTE_HOST": 1,
	"HTTPS": 1,
	"HTTP_REFERER": 1
};

foreach(vars, function(key, val, arr) {
	if(getenv(key) != nil) {
		printf("%s = %s\n", key, getenv(key));
	} else {
		printf("%s not defined\n", key);
	}
});
print("</pre></body></html>");
```
nginx.conf:
```conf
        # pass the Sparkling scripts to FastCGI server listening on 127.0.0.1:9001
        #
        location ~ \.spn$ {
            root           html;
            fastcgi_pass   127.0.0.1:9001;
            fastcgi_index  index.spn;
            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
            include        fastcgi_params;
        }
```
FastCGI is started using: <code>/usr/bin/spawn-fcgi -a 127.0.0.1 -p 9001 -- spn-fcgi</code>

Link to test.spn in action: http://sfan5.duckdns.org:8080/test.spn