### PR TITLE
Compiled-in extending libraries

### DIFF
--- a/doc/libc99.md
+++ b/doc/libc99.md
@@ -1,0 +1,22 @@
+Documentation of the Sparkling C99 library
+===============================================================
+
+The Sparkling C99 library provides functions not provided by the standard
+library which require C99. Here followsa non-formal description of 
+the semantics of the standard library functions.
+
+Note that it is required to call these functions with the correct (specified in
+the "signature" of each function) number of arguments, else they raise an error.
+An exception to this rule is a variadic function (denoted by an ellipsis `...`
+in its argument list), which may be called with at least as many arguments as
+required.
+
+Note that, at the implementation level, the backing C functions that implement
+the standard libraries expect that they are only called through the convenience
+context API, i. e. that their "context info" pointer points to an SpnContext
+structure.
+
+
+    int microtime(void)
+
+Returns the current Unix timestamp in microseconds.

--- a/src/c99/Makefile
+++ b/src/c99/Makefile
@@ -1,0 +1,15 @@
+CFLAGS += -std=c99
+
+SOURCES = $(wildcard $(SRCDIR)/*.c)
+OBJECTS = $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(SOURCES))
+
+all: $(SOURCES) $(OBJECTS)
+
+$(OBJDIR)/%.o: $(SRCDIR)/%.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	$(RM) $(OBJECTS) .DS_Store $(SRCDIR)/.DS_Store $(OBJDIR)/.DS_Store
+
+.PHONY: all install clean
+

--- a/src/c99/rtlb.c
+++ b/src/c99/rtlb.c
@@ -1,0 +1,29 @@
+#include <sys/time.h>
+
+#include "vm.h"
+#include "private.h"
+
+static int rtlb_c99_microtime(SpnValue *ret, int argc, SpnValue *argv, void *ctx)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	*ret = makeint(1000000 * tv.tv_sec + tv.tv_usec);
+
+	return 0;
+}
+
+#define SPN_LIBSIZE_C99 1
+const SpnExtFunc spn_libc99[SPN_LIBSIZE_C99] = {
+	{ "microtime",	rtlb_c99_microtime	},
+};
+
+void spn_libc99_load(SpnVMachine *vm)
+{
+	spn_vm_addlib_cfuncs(vm, NULL, spn_libc99, SPN_LIBSIZE_C99);
+}
+
+__attribute__((constructor)) void spn_libc99_c()
+{
+	/* Tell Sparkling to call spn_libc99_load when the standard library is loaded */
+	spn_add_libld(spn_libc99_load);
+}

--- a/src/private.c
+++ b/src/private.c
@@ -12,6 +12,9 @@
 
 #include "private.h"
 
+static spn_libld_func libld_funcs[100];
+static int spn_libld_n = 0;
+
 int nth_arg_idx(spn_uword *ip, int idx)
 {
 	int wordidx = idx / SPN_WORD_OCTETS;
@@ -43,5 +46,17 @@ void *spn_realloc(void *ptr, size_t n)
 	}
 
 	return ret;
+}
+
+void spn_add_libld(spn_libld_func f)
+{
+	libld_funcs[spn_libld_n++] = f;
+}
+
+void spn_run_libld(SpnVMachine *vm)
+{
+	int i;
+	for(i = 0; i < spn_libld_n; i++)
+		libld_funcs[i](vm);
 }
 

--- a/src/private.h
+++ b/src/private.h
@@ -14,6 +14,7 @@
 #include <assert.h>
 
 #include "api.h"
+#include "vm.h"
 
 
 /* convenience SpnValue-related re-defines. For internal use only! */
@@ -96,6 +97,13 @@ SPN_API int nth_arg_idx(spn_uword *ip, int idx);
 /* "safe" allocator functions */
 SPN_API void *spn_malloc(size_t n);
 SPN_API void *spn_realloc(void *p, size_t n);
+
+/* typedef for function to be called on spn_load_stdlib */
+typedef void (*spn_libld_func)(SpnVMachine *);
+/* register function to be called on spn_load_stdlib */
+SPN_API void spn_add_libld(spn_libld_func f);
+/* run functions registered with above function */
+SPN_API void spn_run_libld(SpnVMachine *vm);
 
 #endif /* SPN_PRIVATE_H */
 

--- a/src/rtlb.c
+++ b/src/rtlb.c
@@ -2740,5 +2740,6 @@ void spn_load_stdlib(SpnVMachine *vm)
 {
 	load_stdlib_functions(vm);
 	load_stdlib_constants(vm);
+	spn_run_libld(vm);
 }
 


### PR DESCRIPTION
This implements my idea of additional libraries you can add into Sparkling at compile time.
To illustrate how it works by describing how one would add sqlite3 bindings:

1) Add <code>MOD_SQLITE3 ?= 0 # sqlite3 binding</code> at after the <code>MOD_C99 ?= 0</code> line
2) Add

``` make
ifeq ($(MOD_SQLITE3), 1)
    MODS += sqlite3
    LIBS += -lsqlite3
    ADDITIONAL_OBJS += $(OBJDIR)/sqlite3/*.o
endif
```

before the <code>ifneq ($(READLINE), 0)</code> line
3) Create an src/sqlite3 folder
4) Put

``` make
SOURCES = $(wildcard $(SRCDIR)/*.c)
OBJECTS = $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(SOURCES))

all: $(SOURCES) $(OBJECTS)

$(OBJDIR)/%.o: $(SRCDIR)/%.c
    $(CC) $(CFLAGS) -o $@ $<

clean:
    $(RM) $(OBJECTS) .DS_Store $(SRCDIR)/.DS_Store $(OBJDIR)/.DS_Store

.PHONY: all install clean
```

into src/sqlite3/Makefile
5) Implement stuff in src/sqlite3/rtlb.c
6) Then create a function <code>void (SpnVMachine *)</code> which registers globals & functions in the VM.
7) Finally add an <code>__attribute__((constructor))</code> function that calls <code>spn_add_libld</code> with the above function to register it to be run after the stdlib was loaded.
8) Create documentation at doc/libsqlite3.md

If you run make with <code>MOD_SQLITE3 = 1</code> now, src/sqlite3/rtlb.c will get compiled and linked into libspn.a, libspn.so and the interpreter executable.
