### PR TITLE
assert() now accepts formatted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ apply syntax highlighting on your code.
 Notepad++ users can import `tools/sparkling-npp.xml` via
 **Language**->**Define your language...***->**[ Import... ]**
 
+Atom users can run the script `tools/sparkling-atom-install.sh`
+
 Portability note:
 =================
 The **code** is portable and cross-platform (at least that is my aim), but the
@@ -215,4 +217,3 @@ possible solution, respectively:
 Happy programming!
 
 -- H2CO3
-

--- a/doc/stdlib.md
+++ b/doc/stdlib.md
@@ -510,10 +510,10 @@ Returns the value of the environment variable `name`, or `nil` if it's not set.
 
 Runs the command `cmd` in the shell, returns the exit status.
 
-    nil assert(bool cond [, string errmsg])
+    nil assert(bool cond [, string format, ...])
 
 Evaluates `cond`, and if it is false, terminates the program, printing the
-error message to the standard error stream.
+formatted error message to the standard error stream.
 
     int time(void)
 


### PR DESCRIPTION
`assert(cond, str.format(...))`

is now replaced with:

`assert(cond, str, ...)`

Where `str`and the rest of the arguments are all optional.